### PR TITLE
Add feature to only process an SES event a single time

### DIFF
--- a/database/migrations/create_mailcoach_ses_tables.php.stub
+++ b/database/migrations/create_mailcoach_ses_tables.php.stub
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMailcoachSesTables extends Migration
+{
+    public function up()
+    {
+        Schema::create('mailcoach_ses_processed_messages', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('ses_message_id');
+
+            $table->timestamps();
+        });
+
+    }
+}

--- a/src/MailcoachSesFeedbackServiceProvider.php
+++ b/src/MailcoachSesFeedbackServiceProvider.php
@@ -10,11 +10,26 @@ use Illuminate\Support\ServiceProvider;
 
 class MailcoachSesFeedbackServiceProvider extends ServiceProvider
 {
+
+    public function boot()
+    {
+        $this->bootPublishables();
+    }
+
     public function register()
     {
         Route::macro('sesFeedback', fn (string $url) => Route::post($url, '\\' . SesWebhookController::class));
 
         Event::listen(MessageSending::class, AddConfigurationSetHeader::class);
         Event::listen(MessageSent::class, StoreTransportMessageId::class);
+    }
+
+    protected function bootPublishables()
+    {
+        $this->publishes([
+            __DIR__ . '/../database/migrations/create_mailcoach_ses_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_mailcoach_ses_tables.php'),
+        ], 'mailcoach-ses-feedback-migrations');
+
+        return $this;
     }
 }

--- a/src/Models/SesProcessedMessage.php
+++ b/src/Models/SesProcessedMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\MailcoachSesFeedback\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SesProcessedMessage extends Model
+{
+    public $table = 'mailcoach_ses_processed_messages';
+
+    protected $guarded = [];
+
+    protected $casts = [
+
+    ];
+
+}

--- a/src/ProcessSesWebhooksProfile.php
+++ b/src/ProcessSesWebhooksProfile.php
@@ -6,6 +6,7 @@ use Aws\Sns\Message;
 use Exception;
 use Illuminate\Http\Request;
 use Spatie\WebhookClient\WebhookProfile\WebhookProfile;
+use Spatie\MailcoachSesFeedback\Models\SesProcessedMessage;
 
 class ProcessSesWebhooksProfile implements WebhookProfile
 {
@@ -13,7 +14,8 @@ class ProcessSesWebhooksProfile implements WebhookProfile
     {
         try {
             $message = Message::fromRawPostData();
-            return true;
+
+            return !SesProcessedMessage::whereSesMessageId($message->MessageId)->exists();
         } catch (Exception $e) {
             return false;
         }

--- a/src/SesEvents/Click.php
+++ b/src/SesEvents/Click.php
@@ -14,5 +14,7 @@ class Click extends SesEvent
     public function handle(Send $send)
     {
         $send->registerClick($this->payload['click']['link']);
+
+        $this->storeSESMessageId();
     }
 }

--- a/src/SesEvents/Complaint.php
+++ b/src/SesEvents/Complaint.php
@@ -14,5 +14,7 @@ class Complaint extends SesEvent
     public function handle(Send $send)
     {
         $send->registerComplaint();
+
+        $this->storeSESMessageId();
     }
 }

--- a/src/SesEvents/Open.php
+++ b/src/SesEvents/Open.php
@@ -18,5 +18,7 @@ class Open extends SesEvent
         }
 
         $send->registerOpen();
+
+        $this->storeSESMessageId();
     }
 }

--- a/src/SesEvents/PermanentBounce.php
+++ b/src/SesEvents/PermanentBounce.php
@@ -22,5 +22,7 @@ class PermanentBounce extends SesEvent
     public function handle(Send $send)
     {
         $send->registerBounce();
+
+        $this->storeSESMessageId();
     }
 }

--- a/src/SesEvents/SesEvent.php
+++ b/src/SesEvents/SesEvent.php
@@ -3,6 +3,7 @@
 namespace Spatie\MailcoachSesFeedback\SesEvents;
 
 use Spatie\Mailcoach\Models\Send;
+use Spatie\MailcoachSesFeedback\Models\SesProcessedMessage;
 
 abstract class SesEvent
 {
@@ -16,4 +17,12 @@ abstract class SesEvent
     abstract public function canHandlePayload(): bool;
 
     abstract public function handle(Send $send);
+
+    public function storeSESMessageId() {
+
+        SesProcessedMessage::create([
+            'ses_message_id' => $this->payload['SesMessageId']
+        ]);
+
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Spatie\MailcoachSesFeedback\Tests;
 
 use CreateMailcoachTables;
 use CreateWebhookCallsTable;
+use CreateMailcoachSesTables;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\BladeX\BladeXServiceProvider;
@@ -51,6 +52,9 @@ class TestCase extends Orchestra
 
         include_once __DIR__ . '/../vendor/spatie/laravel-mailcoach/database/migrations/create_mailcoach_tables.php.stub';
         (new CreateMailcoachTables())->up();
+
+        include_once __DIR__ . '/../database/migrations/create_mailcoach_ses_tables.php.stub';
+        (new CreateMailcoachSesTables())->up();
     }
 
     public function getStub(string $name): array


### PR DESCRIPTION
Fixes spatie/mailcoach-support#75

First attempt at adding a precheck before processing an event from SES.

The idea is to store the SNS message id to a database table and check its existence in said table before queueing the proccessing job.

A second existence check is made just before the SesEvent is handled. This is to prevent edge cases when a 2nd SES event is webhooked before the 1st event's job is processed. This is probably not needed, but left it in for feedback.

My first attempt at committing the message_id to the database was as a listener to the 4 events in the Spatie\Mailcoach\Events namespace. The problem with this approach is in passing along the SNS message id through the events (in the core Mailcoach package).

I settled, for this draft PR, on calling a method on the SesEvent abstract class at the end of the 4 child classes' handle() method. I am open to other ideas on when in the code execution the message_id should be committed to the database.

**Things yet to be committed to this PR:**
1. Scheduled artisan console command to clear records in the new database table older than 24 hours (maybe a week?)
2. All testing
3. Code styling

I am submitting this incomplete PR to gather feedback from @freekmurze and his team.

This is my first non-documentation PR (of hopefully many). Please go easy on me :)