### PR TITLE
Add existence check for identical message in webhook_calls before processing

### DIFF
--- a/src/ProcessSesWebhookJob.php
+++ b/src/ProcessSesWebhookJob.php
@@ -21,13 +21,13 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
 
     public function handle()
     {
-        if (! $this->webhookCall->isFirstOfThisSesMessage()) {
+        if (! $message = $this->getMessageFromWebhookCall()) {
             $this->webhookCall->delete();
 
             return;
         }
 
-        if (! $message = $this->getMessageFromWebhookCall()) {
+        if (! $this->webhookCall->isFirstOfThisSesMessage()) {
             $this->webhookCall->delete();
 
             return;

--- a/src/ProcessSesWebhookJob.php
+++ b/src/ProcessSesWebhookJob.php
@@ -21,6 +21,10 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
 
     public function handle()
     {
+        if ($this->webhookCall->identicalMessageExists()) {
+            return;
+        }
+
         if (! $message = $this->getMessageFromWebhookCall()) {
             $this->webhookCall->delete();
 

--- a/src/ProcessSesWebhookJob.php
+++ b/src/ProcessSesWebhookJob.php
@@ -21,7 +21,9 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
 
     public function handle()
     {
-        if ($this->webhookCall->identicalMessageExists()) {
+        if (! $this->webhookCall->isFirstOfThisSesMessage()) {
+            $this->webhookCall->delete();
+
             return;
         }
 

--- a/src/SesWebhookCall.php
+++ b/src/SesWebhookCall.php
@@ -20,4 +20,10 @@ class SesWebhookCall extends WebhookCall
             'payload' => $message->toArray(),
         ]);
     }
+
+    public function identicalMessageExists() {
+        return SesWebhookCall::where('id', '<>', $this->id)
+                                ->where('payload->MessageId', $this->payload['MessageId'])
+                                ->exists();
+    }
 }

--- a/src/SesWebhookCall.php
+++ b/src/SesWebhookCall.php
@@ -21,14 +21,11 @@ class SesWebhookCall extends WebhookCall
         ]);
     }
 
-    public static function getFirstIdOfThisSesMessage(string $ses_message_id): int
-    {
-        return SesWebhookCall::where('payload->MessageId', $ses_message_id)
-                                ->min('id');
-    }
-
     public function isFirstOfThisSesMessage(): bool
     {
-        return $this->id === SesWebhookCall::getFirstIdOfThisSesMessage($this->payload['MessageId']);
+        $first_message_id = (int) SesWebhookCall::where('payload->MessageId', $this->payload['MessageId'])
+                                                    ->min('id');
+
+        return $this->id === $first_message_id;
     }
 }

--- a/src/SesWebhookCall.php
+++ b/src/SesWebhookCall.php
@@ -21,10 +21,14 @@ class SesWebhookCall extends WebhookCall
         ]);
     }
 
+    public static function getFirstIdOfThisSesMessage(string $ses_message_id): int
+    {
+        return SesWebhookCall::where('payload->MessageId', $ses_message_id)
+                                ->min('id');
+    }
+
     public function isFirstOfThisSesMessage(): bool
     {
-        $first = SesWebhookCall::where('payload->MessageId', $this->payload['MessageId'])
-                                    ->min('id');
-        return $this->id === $first;
+        return $this->id === SesWebhookCall::getFirstIdOfThisSesMessage($this->payload['MessageId']);
     }
 }

--- a/src/SesWebhookCall.php
+++ b/src/SesWebhookCall.php
@@ -21,7 +21,8 @@ class SesWebhookCall extends WebhookCall
         ]);
     }
 
-    public function identicalMessageExists() {
+    public function identicalMessageExists(): bool
+    {
         return SesWebhookCall::where('id', '<>', $this->id)
                                 ->where('payload->MessageId', $this->payload['MessageId'])
                                 ->exists();

--- a/src/SesWebhookCall.php
+++ b/src/SesWebhookCall.php
@@ -21,10 +21,10 @@ class SesWebhookCall extends WebhookCall
         ]);
     }
 
-    public function identicalMessageExists(): bool
+    public function isFirstOfThisSesMessage(): bool
     {
-        return SesWebhookCall::where('id', '<>', $this->id)
-                                ->where('payload->MessageId', $this->payload['MessageId'])
-                                ->exists();
+        $first = SesWebhookCall::where('payload->MessageId', $this->payload['MessageId'])
+                                    ->min('id');
+        return $this->id === $first;
     }
 }

--- a/tests/ProcessSesWebhookJobTest.php
+++ b/tests/ProcessSesWebhookJobTest.php
@@ -10,7 +10,7 @@ use Spatie\WebhookClient\Models\WebhookCall;
 
 class ProcessSesWebhookJobTest extends TestCase
 {
-    private WebhookCall $webhookCall;
+    private SesWebhookCall $webhookCall;
 
     private Send $send;
 
@@ -18,7 +18,7 @@ class ProcessSesWebhookJobTest extends TestCase
     {
         parent::setUp();
 
-        $this->webhookCall = WebhookCall::create([
+        $this->webhookCall = SesWebhookCall::create([
             'name' => 'ses',
             'payload' => $this->getStub('bounceWebhookContent'),
         ]);
@@ -79,7 +79,7 @@ class ProcessSesWebhookJobTest extends TestCase
     /** @test */
     public function it_processes_a_ses_webhook_call_for_clicks()
     {
-        $webhookCall = WebhookCall::create([
+        $webhookCall = SesWebhookCall::create([
             'name' => 'ses',
             'payload' => $this->getStub('clickWebhookContent'),
         ]);
@@ -98,7 +98,7 @@ class ProcessSesWebhookJobTest extends TestCase
     /** @test */
     public function it_processes_a_ses_webhook_call_for_opens()
     {
-        $webhookCall = WebhookCall::create([
+        $webhookCall = SesWebhookCall::create([
             'name' => 'ses',
             'payload' => $this->getStub('openWebhookContent'),
         ]);
@@ -117,7 +117,7 @@ class ProcessSesWebhookJobTest extends TestCase
     /** @test */
     public function it_processes_a_ses_webhook_call_for_complaints()
     {
-        $webhookCall = WebhookCall::create([
+        $webhookCall = SesWebhookCall::create([
             'name' => 'ses',
             'payload' => $this->getStub('complaintWebhookContent'),
         ]);

--- a/tests/ProcessSesWebhookJobTest.php
+++ b/tests/ProcessSesWebhookJobTest.php
@@ -154,4 +154,20 @@ class ProcessSesWebhookJobTest extends TestCase
 
         $this->assertEquals(0, SendFeedbackItem::count());
     }
+
+    /** @test * */
+    public function it_does_nothing_and_deletes_the_call_if_it_is_a_duplicate_ses_message_id()
+    {
+        $webhookCallSecond = SesWebhookCall::create([
+            'name' => 'ses',
+            'payload' => $this->getStub('bounceWebhookContent'),
+        ]);
+
+        (new ProcessSesWebhookJob($this->webhookCall))->handle();
+        (new ProcessSesWebhookJob($webhookCallSecond))->handle();
+
+        $this->assertEquals(1, SendFeedbackItem::count());
+        $this->assertEquals(1, SesWebhookCall::count());
+    }
+
 }


### PR DESCRIPTION
Sister PR to #1 

Attempts to minimize code additions for a fix to spatie/mailcoach-support#75

This queries the webhook_calls table to look for other webhooks with the same SNS message id before processing the payload as discussed in pull request #1 

There is an issue with this approach. Say the queue is busy and multiple identical webhooks come in from SNS. They are inserted into webhook_calls and get queued. The first in the queue then starts to process. The existence check queries webhook_calls and sees other webhooks with the same SNS message id. The processing stops and the open/click is not logged to mailcoach.

I am putting up this PR to further discuss the best approach to fixing spatie/mailcoach-support#75