### PR TITLE
L7 route caching issue

### DIFF
--- a/src/MailcoachSesFeedbackServiceProvider.php
+++ b/src/MailcoachSesFeedbackServiceProvider.php
@@ -12,7 +12,7 @@ class MailcoachSesFeedbackServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        Route::macro('sesFeedback', fn (string $url) => Route::post($url, '\\' . SesWebhookController::class));
+        Route::macro('sesFeedback', fn (string $url) => Route::post($url, SesWebhookController::class));
 
         Event::listen(MessageSending::class, AddConfigurationSetHeader::class);
         Event::listen(MessageSent::class, StoreTransportMessageId::class);


### PR DESCRIPTION
Remove \\ from webhook controller definition to solve issues with L7 route caching. I'm not sure if the `\\` is there for a reason, but removing it solves the issues with route caching. Same applies to the other feedback packages.

Laravel compares the controller names here: `vendor/laravel/framework/src/Illuminate/Routing/CompiledRouteCollection.php:215` But as the action doesn't have a `\` and the controller does, the comparison fails.