### PR TITLE
dispatch job on mailcoach queue_connecton setting

### DIFF
--- a/src/ProcessSesWebhookJob.php
+++ b/src/ProcessSesWebhookJob.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Spatie\Mailcoach\Models\Send;
 use Spatie\WebhookClient\Models\WebhookCall;
 use Spatie\WebhookClient\ProcessWebhookJob;
+use Spatie\Mailcoach\Support\Config;
 
 class ProcessSesWebhookJob extends ProcessWebhookJob
 {
@@ -17,6 +18,8 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
         parent::__construct($webhookCall);
 
         $this->queue = config('mailcoach.perform_on_queue.process_feedback_job');
+
+        $this->connection = $this->connection ?? Config::getQueueConnection();
     }
 
     public function handle()


### PR DESCRIPTION
Changed webhook jobs to be dispatched on a queue, as defined by mailcoach's 2.1.0 release