### PR TITLE
Simplify message validation

### DIFF
--- a/src/ProcessSesWebhookJob.php
+++ b/src/ProcessSesWebhookJob.php
@@ -25,7 +25,7 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
 
     public function handle()
     {
-        if (! $message = $this->getMessageFromWebhookCall()) {
+        if (! $this->validateMessageFromWebhookCall()) {
             $this->webhookCall->delete();
 
             return;
@@ -57,20 +57,16 @@ class ProcessSesWebhookJob extends ProcessWebhookJob
         event(new WebhookCallProcessedEvent($this->webhookCall));
     }
 
-    protected function getMessageFromWebhookCall(): ?Message
+    protected function validateMessageFromWebhookCall(): bool
     {
         $validator = new MessageValidator();
 
         try {
             $message = Message::fromJsonString(json_encode($this->webhookCall->payload));
         } catch (Exception $exception) {
-            return null;
+            return false;
         }
 
-        if (!$validator->isValid($message)) {
-            return null;
-        }
-
-        return $message;
+        return $validator->isValid($message);
     }
 }


### PR DESCRIPTION
The `$message` variable isn't used after the check, so we can cleanup the validator a bit. 