### PR TITLE
Laravel 7 & 8 default mail compability.

### DIFF
--- a/src/AddConfigurationSetHeader.php
+++ b/src/AddConfigurationSetHeader.php
@@ -8,7 +8,7 @@ class AddConfigurationSetHeader
 {
     public function handle(MessageSending $event)
     {
-        if (! config('mail.driver') === 'ses') {
+        if (! (config('mail.driver') === 'ses' || config('mail.default') === 'ses')) {
             return;
         }
 

--- a/src/AddConfigurationSetHeader.php
+++ b/src/AddConfigurationSetHeader.php
@@ -8,7 +8,7 @@ class AddConfigurationSetHeader
 {
     public function handle(MessageSending $event)
     {
-        if (! (config('mail.driver') === 'ses' || config('mail.default') === 'ses')) {
+        if (! in_array('ses', [config('mail.driver'), config('mail.default')])) {
             return;
         }
 


### PR DESCRIPTION
In version 7+, Laravel changed config('mail.driver') to config('mail.default'). This package will not work for people using 7+ defaults, because it will never set a configuration-set header unless you use Laravel 6 or lower config. This patches to allow for compatibility with all versions.

```
<?php

namespace Spatie\MailcoachSesFeedback;

use Illuminate\Mail\Events\MessageSending;

class AddConfigurationSetHeader
{
    public function handle(MessageSending $event)
    {
        if (! config('mail.driver') === 'ses') {
            return;
        }

        if (! $configuration_set = config('mailcoach.ses_feedback.configuration_set')) {
            return;
        }

        if (! $event->message->getHeaders()->get('X-MAILCOACH')) {
            return;
        }

        $event->message->getHeaders()->removeAll('X-SES-CONFIGURATION-SET');
        $event->message->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', $configuration_set);
    }
}
```