### PR TITLE
Allows custom mailer with "ses" transport

### DIFF
--- a/src/AddConfigurationSetHeader.php
+++ b/src/AddConfigurationSetHeader.php
@@ -8,7 +8,9 @@ class AddConfigurationSetHeader
 {
     public function handle(MessageSending $event)
     {
-        if (! in_array('ses', [config('mail.driver'), config('mail.default'), config('mail.mailers.mailcoach.transport')])) {
+        $driver = config('mailcoach.mailer') ?? config('mailcoach.campaign_mailer') ?? config('mail.default');
+        
+        if ('ses' !== config("mail.mailers.{$driver}.transport")) {
             return;
         }
 


### PR DESCRIPTION
Currently, it's not possible to track emails with a custom `mailer` for example:

```
// config/mail.php

'mailers' => [
    ...

    'my-custom-mailer-for-campaign' => [
        'key' => 'xxxxxxxxxxxxxxxxxxx',
        'secret' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
        'region' => 'us-east-2',
        'transport' => 'ses',
        'version' => 'latest',
        'service' => 'email',
    ],
    
]
```

```
// config/mailcoach.php

return [
    'mailer' => 'my-custom-mailer',

    'campaign_mailer' => 'my-custom-mailer-for-campaign',
]
```

This pull allows us to use the above configuration by checking if `mailer` transport is `ses`.